### PR TITLE
Update davinci pricing from 0.01$/K to 0.02$/K to match OpenAI website

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -194,10 +194,10 @@ async def show_balance_handle(update: Update, context: CallbackContext):
     db.set_user_attribute(user_id, "last_interaction", datetime.now())
 
     n_used_tokens = db.get_user_attribute(user_id, "n_used_tokens")
-    n_spent_dollars = n_used_tokens * (0.01 / 1000)
+    n_spent_dollars = n_used_tokens * (0.02 / 1000)
 
     text = f"You spent <b>{n_spent_dollars:.03f}$</b>\n"
-    text += f"You used <b>{n_used_tokens}</b> tokens <i>(price: 0.01$ per 1000 tokens)</i>\n"
+    text += f"You used <b>{n_used_tokens}</b> tokens <i>(price: 0.02$ per 1000 tokens)</i>\n"
 
     await update.message.reply_text(text, parse_mode=ParseMode.HTML)
 


### PR DESCRIPTION
This PR updates davinci pricing from 0.01/K to 0.02/K to match with OpenAI official pricing https://openai.com/api/pricing/

Hi! 
Thanks for the amazing project, I have been using the bot for extensive amount of time, however I noticed the pricing in `/balance` command differs with OpenAI's official pricing. And this can be confirmed on https://openai.com/api/pricing/ and according my own usage, my account billing page is showing twice the amount compared to `/balance` command suggested. 

This may be confusing for some users seeing they being charged twice the money suggested by the bot.
