### PR TITLE
Reference config.env from within docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ mv config/config.example.env config/config.env
 🔥 And now **run**:
 
 ```bash
-docker-compose --env-file config/config.env up --build
+docker-compose -f docker-compose.yml up --build
 ```
 
 ## References

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - ${MONGODB_PORT:-27017}:${MONGODB_PORT:-27017}
     volumes:
       - ${MONGODB_PATH:-./mongodb}:/data/db
+    env_file:
+      - config/config.env
+
     # TODO: add auth
 
   chatgpt_telegram_bot:
@@ -18,6 +21,8 @@ services:
     build:
       context: "."
       dockerfile: Dockerfile
+    env_file:
+    - config/config.env
     depends_on:
       - mongo
 
@@ -34,5 +39,7 @@ services:
       - ME_CONFIG_MONGODB_AUTH_DATABASE=chatgpt_telegram_bot
       - ME_CONFIG_BASICAUTH_USERNAME=${MONGO_EXPRESS_USERNAME:-username}
       - ME_CONFIG_BASICAUTH_PASSWORD=${MONGO_EXPRESS_PASSWORD:-password}
+    env_file:
+    - config/config.env
     depends_on:
       - mongo


### PR DESCRIPTION
- more organized
- easier docker usage on Windows machines where setting env file is [tricky](https://forums.docker.com/t/how-to-set-environment-variables-in-command-prompt-so-theyre-passed-in-docker-run-e-foo-e/106776/6)
But...
- won't run unless config.env exists so assumed previous instructions are followed regarding renaming