### PR TITLE
Can add custom modes in config file

### DIFF
--- a/bot/chatgpt.py
+++ b/bot/chatgpt.py
@@ -30,6 +30,9 @@ CHAT_MODES = {
     },
 }
 
+for mode in config.modes:
+    CHAT_MODES[mode] = config.modes[mode]
+
 OPENAI_COMPLETION_OPTIONS = {
     "temperature": 0.7,
     "max_tokens": 1000,

--- a/bot/config.py
+++ b/bot/config.py
@@ -17,4 +17,5 @@ openai_api_key = config_yaml["openai_api_key"]
 use_chatgpt_api = config_yaml.get("use_chatgpt_api", True)
 allowed_telegram_usernames = config_yaml["allowed_telegram_usernames"]
 new_dialog_timeout = config_yaml["new_dialog_timeout"]
+modes = config_yaml.ge("modes", {})
 mongodb_uri = f"mongodb://mongo:{config_env['MONGODB_PORT']}"

--- a/bot/config.py
+++ b/bot/config.py
@@ -17,5 +17,5 @@ openai_api_key = config_yaml["openai_api_key"]
 use_chatgpt_api = config_yaml.get("use_chatgpt_api", True)
 allowed_telegram_usernames = config_yaml["allowed_telegram_usernames"]
 new_dialog_timeout = config_yaml["new_dialog_timeout"]
-modes = config_yaml.ge("modes", {})
+modes = config_yaml.get("modes", {})
 mongodb_uri = f"mongodb://mongo:{config_env['MONGODB_PORT']}"

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -3,3 +3,8 @@ openai_api_key: ""
 use_chatgpt_api: true
 allowed_telegram_usernames: []  # if empty, the bot is available to anyone
 new_dialog_timeout: 600  # new dialog starts after timeout (in seconds)
+modes:
+  svg:
+    name: "👩‍🎨 SVG designer"
+    welcome_message: "👩‍🎨 Hi, I'm <b>ChatGPT SVG designer</b>. How can I help you?"
+    prompt_start: "I would like you to act as an SVG designer. I will ask you to create images, and you will come up with SVG code for the image and then give me a response that contains only an image SVG tag. Do not put the code inside a code block. Send only the code, so no text."


### PR DESCRIPTION
Example mode added:

```yaml
modes:
  svg:
    name: "👩‍🎨 SVG designer"
    welcome_message: "👩‍🎨 Hi, I'm <b>ChatGPT SVG designer</b>. How can I help you?"
    prompt_start: "I would like you to act as an SVG designer. I will ask you to create images, and you will come up with SVG code for the image and then give me a response that contains only an image SVG tag. Do not put the code inside a code block. Send only the code, so no text."
```