### PR TITLE
Docker improvements, configfile-less run, CI workflow 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - id: lowercaseRepo
+      uses: ASzc/change-string-case-action@v5
+      with:
+        string: ${{ github.repository }}
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to GHCR
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create short sha and tag
+      shell: bash
+      run: |
+        echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+        if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then echo TAG=latest; else echo TAG="${GITHUB_REF##*/}"; fi >> $GITHUB_ENV
+    - name: Build Docker Image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ env.SHORT_SHA }}
+          ghcr.io/${{ steps.lowercaseRepo.outputs.lowercase }}:${{ env.TAG }}
+        platforms: linux/amd64,linux/arm64
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM python:3.8-slim
+# syntax=docker/dockerfile:labs
 
+FROM python:3.8-slim as builder
+ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONFAULTHANDLER=1
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONHASHSEED=random
@@ -9,12 +11,18 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=on
 ENV PIP_DEFAULT_TIMEOUT=100
 
 RUN apt-get update
-RUN apt-get install -y python3 python3-pip python-dev build-essential python3-venv
+RUN apt-get install -y --no-install-recommends python3 python3-pip python3-dev build-essential python3-venv
 
-RUN mkdir -p /code
-ADD . /code
-WORKDIR /code
+WORKDIR /build
+ADD requirements.txt requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip3 wheel --wheel-dir=/wheels -r requirements.txt
 
-RUN pip3 install -r requirements.txt
+FROM python:3.8-slim
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /app
+ADD requirements.txt requirements.txt
+RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels pip3 install --upgrade --no-index --find-links=/wheels -r requirements.txt
 
-CMD ["bash"]
+ADD . /app
+
+CMD /usr/local/bin/python /app/bot/bot.py

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,3 +1,4 @@
+import os
 import yaml
 import dotenv
 from pathlib import Path
@@ -5,16 +6,18 @@ from pathlib import Path
 config_dir = Path(__file__).parent.parent.resolve() / "config"
 
 # load yaml config
-with open(config_dir / "config.yml", 'r') as f:
-    config_yaml = yaml.safe_load(f)
-
+try:
+    with open(config_dir / "config.yml", 'r') as f:
+        config_yaml = yaml.safe_load(f)
+except:
+    config_yaml = {}
 # load .env config
 config_env = dotenv.dotenv_values(config_dir / "config.env")
 
 # config parameters
-telegram_token = config_yaml["telegram_token"]
-openai_api_key = config_yaml["openai_api_key"]
-use_chatgpt_api = config_yaml.get("use_chatgpt_api", True)
-allowed_telegram_usernames = config_yaml["allowed_telegram_usernames"]
-new_dialog_timeout = config_yaml["new_dialog_timeout"]
-mongodb_uri = f"mongodb://mongo:{config_env['MONGODB_PORT']}"
+telegram_token = os.getenv('TELEGRAM_TOKEN', config_yaml.get("telegram_token"))
+openai_api_key =  os.getenv('OPENAI_API_KEY', config_yaml.get("openai_api_key"))
+use_chatgpt_api =  os.getenv('USE_CHATGPT_API', config_yaml.get("use_chatgpt_api", True))
+allowed_telegram_usernames =  config_yaml.get('allowed_telegram_usernames', os.getenv("TELEGRAM_USERNAMES", "").split(','))
+new_dialog_timeout =  int(os.getenv("NEW_DIALOG_TIMEOUT", config_yaml.get("new_dialog_timeout")))
+mongodb_uri = "mongodb://mongo:"+config_env.get('MONGODB_PORT', "27017")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,24 @@
 version: "3"
+volumes:
+  mongodb_data:
 
 services:
   mongo:
     container_name: mongo
     image: mongo:latest
     restart: always
-    ports:
-      - ${MONGODB_PORT:-27017}:${MONGODB_PORT:-27017}
     volumes:
-      - ${MONGODB_PATH:-./mongodb}:/data/db
+      - mongodb_data:/data/db
     # TODO: add auth
 
   chatgpt_telegram_bot:
     container_name: chatgpt_telegram_bot
-    command: python3 bot/bot.py
     restart: always
+    environment:
+      - TELEGRAM_TOKEN=
+      - OPENAI_API_KEY=
+      - USE_CHATGPT_API=True
+      - NEW_DIALOG_TIMEOUT=600
     build:
       context: "."
       dockerfile: Dockerfile


### PR DESCRIPTION
Example of configfile-less run:

```
chatgpt_telegram_bot:
    container_name: chatgpt_telegram_bot
    restart: always
    environment:
      - TELEGRAM_TOKEN=
      - OPENAI_API_KEY=
      - USE_CHATGPT_API=True
      - NEW_DIALOG_TIMEOUT=600
      - TELEGRAM_USERNAMES=
```