### PR TITLE
Don't reset dialog if already new

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -98,7 +98,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
 
     # new dialog timeout
     if use_new_dialog_timeout:
-        if (datetime.now() - db.get_user_attribute(user_id, "last_interaction")).seconds > config.new_dialog_timeout:
+        if (datetime.now() - db.get_user_attribute(user_id, "last_interaction")).seconds > config.new_dialog_timeout and len(db.get_dialog_messages(user_id)) > 0:
             db.start_new_dialog(user_id)
             await update.message.reply_text("Starting new dialog due to timeout ✅")
     db.set_user_attribute(user_id, "last_interaction", datetime.now())


### PR DESCRIPTION
If the /new command was the last interaction, and the following interaction takes place after the timeout, this prevents showing a redundant "starting new dialog" message.