### PR TITLE
support proxy setting for openai; add new commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+mongodb/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can deploy your own bot, or use mine: [@chatgpt_karfly_bot](https://t.me/cha
 - `/retry` – Regenerate last bot answer
 - `/new` – Start new dialog
 - `/mode` – Select chat mode
+- `/history` – Show dialog History
 - `/balance` – Show balance
 - `/help` – Show help
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -284,13 +284,16 @@ async def show_chat_modes_handle(update: Update, context: CallbackContext):
     await register_user_if_not_exists(update, context, update.message.from_user)
     user_id = update.message.from_user.id
     db.set_user_attribute(user_id, "last_interaction", datetime.now())
+    cur_mode = db.get_user_attribute(user_id, "current_chat_mode")
 
     keyboard = []
     for chat_mode, chat_mode_dict in openai_utils.CHAT_MODES.items():
         keyboard.append([InlineKeyboardButton(chat_mode_dict["name"], callback_data=f"set_chat_mode|{chat_mode}")])
     reply_markup = InlineKeyboardMarkup(keyboard)
 
-    await update.message.reply_text("Select chat mode:", reply_markup=reply_markup)
+    await update.message.reply_text(
+        f"Your current chat mode is {openai_utils.CHAT_MODES[cur_mode]['name']}. "
+        + "Select chat mode if you want to change:", reply_markup=reply_markup)
 
 
 async def set_chat_mode_handle(update: Update, context: CallbackContext):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -235,17 +235,19 @@ async def answer_timeout_handle(update: Update, context: CallbackContext):
     new_dialog = query.data.split("|")[1]
     dialog_messages = db.get_dialog_messages(user_id, dialog_id=None)
     if len(dialog_messages) == 0:
-        await update.message.reply_text("No history dialog. Start a new one 🤷‍♂️")
-        await new_dialog_handle(update.callback_query, context, user_id)
+        await query.edit_message_text("I don't see any dialog. You are using a new one. 🙅‍♂️")
         return
     elif 'bot' in dialog_messages[-1]:  # already answered, do nothing
+        await query.edit_message_text("I must have served you. 🤷‍♂️")
         return
 
     last_dialog_message = dialog_messages.pop()
     if new_dialog == "true":
+        await query.edit_message_text("Sure, a new dialog. 🫡")
         await new_dialog_handle(update.callback_query, context, user_id)
         await message_handle(update.callback_query, context, message=last_dialog_message["user"], use_new_dialog_timeout=False, user_id=user_id)
     else:  # false
+        await query.edit_message_text("Sure, let's continue. 🫡")
         await retry_handle(update.callback_query, context, user_id)
 
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -18,6 +18,7 @@ use_chatgpt_api = config_yaml.get("use_chatgpt_api", True)
 allowed_telegram_usernames = config_yaml["allowed_telegram_usernames"]
 new_dialog_timeout = config_yaml["new_dialog_timeout"]
 ask_on_timeout = config_yaml["ask_on_timeout"]
+default_chat_mode = config_yaml["default_chat_mode"]
 mongodb_uri = f"mongodb://mongo:{config_env['MONGODB_PORT']}"
 
 # chat_modes

--- a/bot/config.py
+++ b/bot/config.py
@@ -17,6 +17,7 @@ openai_api_key = config_yaml["openai_api_key"]
 use_chatgpt_api = config_yaml.get("use_chatgpt_api", True)
 allowed_telegram_usernames = config_yaml["allowed_telegram_usernames"]
 new_dialog_timeout = config_yaml["new_dialog_timeout"]
+ask_on_timeout = config_yaml["ask_on_timeout"]
 mongodb_uri = f"mongodb://mongo:{config_env['MONGODB_PORT']}"
 
 # chat_modes

--- a/bot/database.py
+++ b/bot/database.py
@@ -44,7 +44,7 @@ class Database:
             "first_seen": datetime.now(),
             
             "current_dialog_id": None,
-            "current_chat_mode": "assistant",
+            "current_chat_mode": config.default_chat_mode,
 
             "n_used_tokens": 0
         }

--- a/bot/openai_utils.py
+++ b/bot/openai_utils.py
@@ -90,7 +90,10 @@ class ChatGPT:
     def _generate_prompt_messages_for_chatgpt_api(self, message, dialog_messages, chat_mode):
         prompt = CHAT_MODES[chat_mode]["prompt_start"]
         
-        messages = [{"role": "system", "content": prompt}]
+        if prompt is not None:
+            messages = [{"role": "system", "content": prompt}]
+        else:
+            messages = []
         for dialog_message in dialog_messages:
             messages.append({"role": "user", "content": dialog_message["user"]})
             messages.append({"role": "assistant", "content": dialog_message["bot"]})

--- a/bot/openai_utils.py
+++ b/bot/openai_utils.py
@@ -1,8 +1,20 @@
+import os
 import config
 
 import openai
 openai.api_key = config.openai_api_key
 
+proxies = {}
+if 'HTTP_PROXY' in os.environ:
+    proxies['http'] = os.environ["HTTP_PROXY"]
+elif 'http_proxy' in os.environ:
+    proxies['http'] = os.environ["http_proxy"]
+
+if 'HTTPS_PROXY' in os.environ:
+    proxies['https'] = os.environ["HTTPS_PROXY"]
+elif 'https_proxy' in os.environ:
+    proxies['https'] = os.environ["https_proxy"]
+openai.proxy = proxies
 
 CHAT_MODES = config.chat_modes
 

--- a/config/chat_modes.yml
+++ b/config/chat_modes.yml
@@ -23,7 +23,7 @@ text_improver:
     
     All your answers strictly follows the structure (keep html tags):
     <b>Edited text:</b>
-    {EDITED TEXT}"
+    {EDITED TEXT}
 
     <b>Correction:</b>
     {NUMBERED LIST OF CORRECTIONS}

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -3,6 +3,7 @@ openai_api_key: ""
 use_chatgpt_api: true
 allowed_telegram_usernames: []  # if empty, the bot is available to anyone
 new_dialog_timeout: 600  # new dialog starts after timeout (in seconds)
+ask_on_timeout: true  # ask whether to start new dialog on timeout
 
 chatgpt_price_per_1000_tokens: 0.002
 gpt_price_per_1000_tokens: 0.02

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -4,6 +4,7 @@ use_chatgpt_api: true
 allowed_telegram_usernames: []  # if empty, the bot is available to anyone
 new_dialog_timeout: 600  # new dialog starts after timeout (in seconds)
 ask_on_timeout: true  # ask whether to start new dialog on timeout
+default_chat_mode: assistant
 
 chatgpt_price_per_1000_tokens: 0.002
 gpt_price_per_1000_tokens: 0.02


### PR DESCRIPTION
- proxy settings, as stated in #110 
- add /history command to display dialogs
	<img width="683" alt="image" src="https://user-images.githubusercontent.com/28671430/224248378-b4611095-7f27-4f14-8dbf-88dc57c90dbc.png">
- add an option in config `ask_on_timeout` to confirm before starting a new dialog on timeout	
	<img width="671" alt="image" src="https://user-images.githubusercontent.com/28671430/224248772-aeaef975-5ebc-4ce7-a3f3-030e04df34e3.png">
