### PR TITLE
Add support for user ids

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -308,10 +308,12 @@ def run_bot() -> None:
     )
 
     # add handlers
-    if len(config.allowed_telegram_usernames) == 0:
-        user_filter = filters.ALL
-    else:
+    user_filter = filters.ALL
+    if len(config.allowed_telegram_usernames) > 0 and isinstance(config.allowed_telegram_usernames[0], str):
         user_filter = filters.User(username=config.allowed_telegram_usernames)
+
+    if len(config.allowed_telegram_usernames) > 0 and isinstance(config.allowed_telegram_usernames[0], int):
+        user_filter = filters.User(user_id=config.allowed_telegram_usernames)
 
     application.add_handler(CommandHandler("start", start_handle, filters=user_filter))
     application.add_handler(CommandHandler("help", help_handle, filters=user_filter))

--- a/bot/config.py
+++ b/bot/config.py
@@ -19,6 +19,9 @@ allowed_telegram_usernames = config_yaml["allowed_telegram_usernames"]
 new_dialog_timeout = config_yaml["new_dialog_timeout"]
 mongodb_uri = f"mongodb://mongo:{config_env['MONGODB_PORT']}"
 
+if not all(isinstance(x, int) for x in allowed_telegram_usernames) or not all(isinstance(x, str) for x in allowed_telegram_usernames):
+    raise TypeError("allowed_telegram_usernames must be a list of integers only or strings only")
+
 # chat_modes
 with open(config_dir / "chat_modes.yml", 'r') as f:
     chat_modes = yaml.safe_load(f)

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -1,7 +1,7 @@
 telegram_token: ""
 openai_api_key: ""
 use_chatgpt_api: true
-allowed_telegram_usernames: []  # if empty, the bot is available to anyone
+allowed_telegram_usernames: []  # if empty, the bot is available to anyone. pass strings to restrict by usernames and ints to restrict by user ids
 new_dialog_timeout: 600  # new dialog starts after timeout (in seconds)
 
 chatgpt_price_per_1000_tokens: 0.002


### PR DESCRIPTION
Allow to filter bot users either by usernames or by user ids.

If the `allowed_telegram_usernames` is filled with strings (e.g: `[username1, username2]`) then we filter by usernames. Otherwise, if it is filled with integers (e.g: `[1234, 5678]`), we filter by user ids.

Was discussed in #107 