### PR TITLE
Make docker builds faster and reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
-FROM python:3.8-slim
+FROM python:3.8-alpine
 
-ENV PYTHONFAULTHANDLER=1
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONHASHSEED=random
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PIP_NO_CACHE_DIR=off
-ENV PIP_DISABLE_PIP_VERSION_CHECK=on
-ENV PIP_DEFAULT_TIMEOUT=100
+ENV PYTHONFAULTHANDLER=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=random \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_DEFAULT_TIMEOUT=100
 
-RUN apt-get update
-RUN apt-get install -y python3 python3-pip python-dev build-essential python3-venv ffmpeg
+RUN apk --no-cache add ffmpeg
 
-RUN mkdir -p /code
-ADD . /code
 WORKDIR /code
+
+COPY requirements.txt /code/
 
 RUN pip3 install -r requirements.txt
 
-CMD ["bash"]
+ADD . /code
+
+CMD ["python3", "/code/bot/bot.py"]


### PR DESCRIPTION
+ switch base image to alpine
+ python3 python3-pip are already included into python base image 
+ build-essential and python3-venv are not used 
+ install requirements before copying the rest of the code, so if changes are only in code/configs - docker uses cached layer with pip packages