### PR TITLE
Fixing permission error

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+mongodb/


### PR DESCRIPTION
Fixing permission error caused by copying mongodb directory into docker image during rebuild.