### PR TITLE
[tested] Updated Dockerfile and docker-compose.yml to simplify bot restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,22 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=on
 ENV PIP_DEFAULT_TIMEOUT=100
 
 RUN apt-get update
-RUN apt-get install -y python3 python3-pip python-dev build-essential python3-venv ffmpeg
+RUN apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    python-dev \
+    build-essential \
+    python3-venv \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /code
+RUN mkdir -p /code/bot /code/config
 ADD . /code
 WORKDIR /code
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+VOLUME ./bot:/code/bot
+VOLUME ./config:/code/config
 
 CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,27 +4,29 @@ services:
   mongo:
     container_name: mongo
     image: mongo:latest
-    restart: always
     ports:
       - 127.0.0.1:${MONGODB_PORT:-27017}:${MONGODB_PORT:-27017}
     volumes:
       - ${MONGODB_PATH:-./mongodb}:/data/db
     # TODO: add auth
+    restart: unless-stopped
 
   chatgpt_telegram_bot:
     container_name: chatgpt_telegram_bot
     command: python3 bot/bot.py
-    restart: always
     build:
       context: "."
       dockerfile: Dockerfile
     depends_on:
       - mongo
+    volumes:
+      - ./bot:/code/bot
+      - ./config:/code/config
+    restart: unless-stopped
 
   mongo_express:
     container_name: mongo-express
     image: mongo-express:latest
-    restart: always
     ports:
       - 127.0.0.1:${MONGO_EXPRESS_PORT:-8081}:${MONGO_EXPRESS_PORT:-8081}
     environment:
@@ -36,3 +38,4 @@ services:
       - ME_CONFIG_BASICAUTH_PASSWORD=${MONGO_EXPRESS_PASSWORD:-password}
     depends_on:
       - mongo
+    restart: unless-stopped


### PR DESCRIPTION
In response to issue #166 :

Updated Dockerfile and docker-compose.yml to use VOLUME mounts for ./bot/ and ./config/ directories, simplifying container restarts for easier bot changes.

Prior to this change, changes to the bot required a docker-compose build to be triggered. With this change, changes can be made with a simple `docker-compose restart`.

This change improves the development experience for contributors; it also keeps the resulting container a bit smaller in size by deleting the lists generated by `apt-get update` which can become quite substantial (>150MB on Ubuntu 22.04)