### PR TITLE
Add stop command feature

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -45,9 +45,6 @@ HELP_MESSAGE = """Commands:
 ⚪ /stop – Stop the dialog
 ⚪ /retry – Regenerate last bot answer
 ⚪ /mode – Select chat mode
-⚪ /settings – Show settings
-⚪ /balance – Show balance
-⚪ /help – Show help
 """
 
 
@@ -476,9 +473,6 @@ async def post_init(application: Application):
         BotCommand("/stop", "Stop the dialog"),
         BotCommand("/mode", "Select chat mode"),
         BotCommand("/retry", "Re-generate response for previous query"),
-        # BotCommand("/balance", "Show balance"),
-        # BotCommand("/settings", "Show settings"),
-        # BotCommand("/help", "Show help message"),
     ])
 
 def run_bot() -> None:
@@ -497,7 +491,6 @@ def run_bot() -> None:
         user_ids = [x for x in config.allowed_telegram_usernames if isinstance(x, int)]
         user_filter = filters.User(username=usernames) | filters.User(user_id=user_ids)
 
-    application.add_handler(CommandHandler("help", help_handle, filters=user_filter))
     application.add_handler(CommandHandler("stop", stop_dialog_handle, filters=user_filter))
     application.add_handler(CommandHandler("new", new_dialog_handle, filters=user_filter))
 
@@ -507,9 +500,6 @@ def run_bot() -> None:
     application.add_handler(MessageHandler(filters.VOICE & user_filter, voice_message_handle))
     application.add_handler(CommandHandler("mode", show_chat_modes_handle, filters=user_filter))
     application.add_handler(CallbackQueryHandler(set_chat_mode_handle, pattern="^set_chat_mode"))
-    application.add_handler(CommandHandler("settings", settings_handle, filters=user_filter))
-    application.add_handler(CallbackQueryHandler(set_settings_handle, pattern="^set_settings"))
-    application.add_handler(CommandHandler("balance", show_balance_handle, filters=user_filter))
     application.add_error_handler(error_handle)
     
     # start the bot

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -38,10 +38,12 @@ import openai_utils
 db = database.Database()
 logger = logging.getLogger(__name__)
 user_semaphores = {}
+listening = True
 
 HELP_MESSAGE = """Commands:
-⚪ /retry – Regenerate last bot answer
 ⚪ /new – Start new dialog
+⚪ /stop – Stop the dialog
+⚪ /retry – Regenerate last bot answer
 ⚪ /mode – Select chat mode
 ⚪ /settings – Show settings
 ⚪ /balance – Show balance
@@ -113,134 +115,136 @@ async def help_handle(update: Update, context: CallbackContext):
 
 
 async def retry_handle(update: Update, context: CallbackContext):
-    await register_user_if_not_exists(update, context, update.message.from_user)
-    if await is_previous_message_not_answered_yet(update, context): return
-    
-    user_id = update.message.from_user.id
-    db.set_user_attribute(user_id, "last_interaction", datetime.now())
+    if listening:
+        await register_user_if_not_exists(update, context, update.message.from_user)
+        if await is_previous_message_not_answered_yet(update, context): return
+        
+        user_id = update.message.from_user.id
+        db.set_user_attribute(user_id, "last_interaction", datetime.now())
 
-    dialog_messages = db.get_dialog_messages(user_id, dialog_id=None)
-    if len(dialog_messages) == 0:
-        await update.message.reply_text("No message to retry 🤷‍♂️")
-        return
+        dialog_messages = db.get_dialog_messages(user_id, dialog_id=None)
+        if len(dialog_messages) == 0:
+            await update.message.reply_text("No message to retry 🤷‍♂️")
+            return
 
-    last_dialog_message = dialog_messages.pop()
-    db.set_dialog_messages(user_id, dialog_messages, dialog_id=None)  # last message was removed from the context
+        last_dialog_message = dialog_messages.pop()
+        db.set_dialog_messages(user_id, dialog_messages, dialog_id=None)  # last message was removed from the context
 
-    await message_handle(update, context, message=last_dialog_message["user"], use_new_dialog_timeout=False)
+        await message_handle(update, context, message=last_dialog_message["user"], use_new_dialog_timeout=False)
 
 
 async def message_handle(update: Update, context: CallbackContext, message=None, use_new_dialog_timeout=True):
-    # check if message is edited
-    if update.edited_message is not None:
-        await edited_message_handle(update, context)
-        return
+    if listening:
+        # check if message is edited
+        if update.edited_message is not None:
+            await edited_message_handle(update, context)
+            return
+            
+        await register_user_if_not_exists(update, context, update.message.from_user)
+        if await is_previous_message_not_answered_yet(update, context): return
+
+        user_id = update.message.from_user.id
+        chat_mode = db.get_user_attribute(user_id, "current_chat_mode")
         
-    await register_user_if_not_exists(update, context, update.message.from_user)
-    if await is_previous_message_not_answered_yet(update, context): return
+        async with user_semaphores[user_id]:
+            # new dialog timeout
+            if use_new_dialog_timeout:
+                if (datetime.now() - db.get_user_attribute(user_id, "last_interaction")).seconds > config.new_dialog_timeout and len(db.get_dialog_messages(user_id)) > 0:
+                    db.start_new_dialog(user_id)
+                    await update.message.reply_text(f"Starting new dialog due to timeout (<b>{openai_utils.CHAT_MODES[chat_mode]['name']}</b> mode) ✅", parse_mode=ParseMode.HTML)
+            db.set_user_attribute(user_id, "last_interaction", datetime.now())
 
-    user_id = update.message.from_user.id
-    chat_mode = db.get_user_attribute(user_id, "current_chat_mode")
-    
-    async with user_semaphores[user_id]:
-        # new dialog timeout
-        if use_new_dialog_timeout:
-            if (datetime.now() - db.get_user_attribute(user_id, "last_interaction")).seconds > config.new_dialog_timeout and len(db.get_dialog_messages(user_id)) > 0:
-                db.start_new_dialog(user_id)
-                await update.message.reply_text(f"Starting new dialog due to timeout (<b>{openai_utils.CHAT_MODES[chat_mode]['name']}</b> mode) ✅", parse_mode=ParseMode.HTML)
-        db.set_user_attribute(user_id, "last_interaction", datetime.now())
+            # send typing action
+            await update.message.chat.send_action(action="typing")
 
-        # send typing action
-        await update.message.chat.send_action(action="typing")
+            try:
+                message = message or update.message.text
 
-        try:
-            message = message or update.message.text
+                current_model = db.get_user_attribute(user_id, "current_model")
+                dialog_messages = db.get_dialog_messages(user_id, dialog_id=None)
+                parse_mode = {
+                    "html": ParseMode.HTML,
+                    "markdown": ParseMode.MARKDOWN
+                }[openai_utils.CHAT_MODES[chat_mode]["parse_mode"]]
 
-            current_model = db.get_user_attribute(user_id, "current_model")
-            dialog_messages = db.get_dialog_messages(user_id, dialog_id=None)
-            parse_mode = {
-                "html": ParseMode.HTML,
-                "markdown": ParseMode.MARKDOWN
-            }[openai_utils.CHAT_MODES[chat_mode]["parse_mode"]]
+                chatgpt_instance = openai_utils.ChatGPT(model=current_model)
+                if config.enable_message_streaming:
+                    gen = chatgpt_instance.send_message_stream(message, dialog_messages=dialog_messages, chat_mode=chat_mode)
+                else:
+                    answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed = await chatgpt_instance.send_message(
+                        message,
+                        dialog_messages=dialog_messages,
+                        chat_mode=chat_mode
+                    )
 
-            chatgpt_instance = openai_utils.ChatGPT(model=current_model)
-            if config.enable_message_streaming:
-                gen = chatgpt_instance.send_message_stream(message, dialog_messages=dialog_messages, chat_mode=chat_mode)
-            else:
-                answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed = await chatgpt_instance.send_message(
-                    message,
-                    dialog_messages=dialog_messages,
-                    chat_mode=chat_mode
+                    async def fake_gen():
+                        yield "finished", answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed
+
+                    gen = fake_gen()
+
+                # send message to user
+                prev_answer = ""
+                i = -1
+                async for gen_item in gen:
+                    i += 1
+
+                    status = gen_item[0]
+                    if status == "not_finished":
+                        status, answer = gen_item
+                    elif status == "finished":
+                        status, answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed = gen_item
+                    else:
+                        raise ValueError(f"Streaming status {status} is unknown")
+
+                    answer = answer[:4096]  # telegram message limit
+                    if i == 0:  # send first message (then it'll be edited if message streaming is enabled)
+                        try:                    
+                            sent_message = await update.message.reply_text(answer, parse_mode=parse_mode)
+                        except telegram.error.BadRequest as e:
+                            if str(e).startswith("Message must be non-empty"):  # first answer chunk from openai was empty
+                                i = -1  # try again to send first message
+                                continue
+                            else:
+                                sent_message = await update.message.reply_text(answer)
+                    else:  # edit sent message
+                        # update only when 100 new symbols are ready
+                        if abs(len(answer) - len(prev_answer)) < 100 and status != "finished":
+                            continue
+
+                        try:                    
+                            await context.bot.edit_message_text(answer, chat_id=sent_message.chat_id, message_id=sent_message.message_id, parse_mode=parse_mode)
+                        except telegram.error.BadRequest as e:
+                            if str(e).startswith("Message is not modified"):
+                                continue
+                            else:
+                                await context.bot.edit_message_text(answer, chat_id=sent_message.chat_id, message_id=sent_message.message_id)
+
+                        await asyncio.sleep(0.01)  # wait a bit to avoid flooding
+                        
+                    prev_answer = answer
+
+                # update user data
+                new_dialog_message = {"user": message, "bot": answer, "date": datetime.now()}
+                db.set_dialog_messages(
+                    user_id,
+                    db.get_dialog_messages(user_id, dialog_id=None) + [new_dialog_message],
+                    dialog_id=None
                 )
 
-                async def fake_gen():
-                    yield "finished", answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed
+                db.update_n_used_tokens(user_id, current_model, n_input_tokens, n_output_tokens) 
+            except Exception as e:
+                error_text = f"Something went wrong during completion. Reason: {e}"
+                logger.error(error_text)
+                await update.message.reply_text(error_text)
+                return
 
-                gen = fake_gen()
-
-            # send message to user
-            prev_answer = ""
-            i = -1
-            async for gen_item in gen:
-                i += 1
-
-                status = gen_item[0]
-                if status == "not_finished":
-                    status, answer = gen_item
-                elif status == "finished":
-                    status, answer, (n_input_tokens, n_output_tokens), n_first_dialog_messages_removed = gen_item
+            # send message if some messages were removed from the context
+            if n_first_dialog_messages_removed > 0:
+                if n_first_dialog_messages_removed == 1:
+                    text = "✍️ <i>Note:</i> Your current dialog is too long, so your <b>first message</b> was removed from the context.\n Send /new command to start new dialog"
                 else:
-                    raise ValueError(f"Streaming status {status} is unknown")
-
-                answer = answer[:4096]  # telegram message limit
-                if i == 0:  # send first message (then it'll be edited if message streaming is enabled)
-                    try:                    
-                        sent_message = await update.message.reply_text(answer, parse_mode=parse_mode)
-                    except telegram.error.BadRequest as e:
-                        if str(e).startswith("Message must be non-empty"):  # first answer chunk from openai was empty
-                            i = -1  # try again to send first message
-                            continue
-                        else:
-                            sent_message = await update.message.reply_text(answer)
-                else:  # edit sent message
-                    # update only when 100 new symbols are ready
-                    if abs(len(answer) - len(prev_answer)) < 100 and status != "finished":
-                        continue
-
-                    try:                    
-                        await context.bot.edit_message_text(answer, chat_id=sent_message.chat_id, message_id=sent_message.message_id, parse_mode=parse_mode)
-                    except telegram.error.BadRequest as e:
-                        if str(e).startswith("Message is not modified"):
-                            continue
-                        else:
-                            await context.bot.edit_message_text(answer, chat_id=sent_message.chat_id, message_id=sent_message.message_id)
-
-                    await asyncio.sleep(0.01)  # wait a bit to avoid flooding
-                    
-                prev_answer = answer
-
-            # update user data
-            new_dialog_message = {"user": message, "bot": answer, "date": datetime.now()}
-            db.set_dialog_messages(
-                user_id,
-                db.get_dialog_messages(user_id, dialog_id=None) + [new_dialog_message],
-                dialog_id=None
-            )
-
-            db.update_n_used_tokens(user_id, current_model, n_input_tokens, n_output_tokens) 
-        except Exception as e:
-            error_text = f"Something went wrong during completion. Reason: {e}"
-            logger.error(error_text)
-            await update.message.reply_text(error_text)
-            return
-
-        # send message if some messages were removed from the context
-        if n_first_dialog_messages_removed > 0:
-            if n_first_dialog_messages_removed == 1:
-                text = "✍️ <i>Note:</i> Your current dialog is too long, so your <b>first message</b> was removed from the context.\n Send /new command to start new dialog"
-            else:
-                text = f"✍️ <i>Note:</i> Your current dialog is too long, so <b>{n_first_dialog_messages_removed} first messages</b> were removed from the context.\n Send /new command to start new dialog"
-            await update.message.reply_text(text, parse_mode=ParseMode.HTML)
+                    text = f"✍️ <i>Note:</i> Your current dialog is too long, so <b>{n_first_dialog_messages_removed} first messages</b> were removed from the context.\n Send /new command to start new dialog"
+                await update.message.reply_text(text, parse_mode=ParseMode.HTML)
 
 
 async def is_previous_message_not_answered_yet(update: Update, context: CallbackContext):
@@ -256,39 +260,43 @@ async def is_previous_message_not_answered_yet(update: Update, context: Callback
 
 
 async def voice_message_handle(update: Update, context: CallbackContext):
-    await register_user_if_not_exists(update, context, update.message.from_user)
-    if await is_previous_message_not_answered_yet(update, context): return
+    if listening:
+        await register_user_if_not_exists(update, context, update.message.from_user)
+        if await is_previous_message_not_answered_yet(update, context): return
 
-    user_id = update.message.from_user.id
-    db.set_user_attribute(user_id, "last_interaction", datetime.now())
+        user_id = update.message.from_user.id
+        db.set_user_attribute(user_id, "last_interaction", datetime.now())
 
-    voice = update.message.voice
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp_dir = Path(tmp_dir)
-        voice_ogg_path = tmp_dir / "voice.ogg"
+        voice = update.message.voice
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            voice_ogg_path = tmp_dir / "voice.ogg"
 
-        # download
-        voice_file = await context.bot.get_file(voice.file_id)
-        await voice_file.download_to_drive(voice_ogg_path)
+            # download
+            voice_file = await context.bot.get_file(voice.file_id)
+            await voice_file.download_to_drive(voice_ogg_path)
 
-        # convert to mp3
-        voice_mp3_path = tmp_dir / "voice.mp3"
-        pydub.AudioSegment.from_file(voice_ogg_path).export(voice_mp3_path, format="mp3")
+            # convert to mp3
+            voice_mp3_path = tmp_dir / "voice.mp3"
+            pydub.AudioSegment.from_file(voice_ogg_path).export(voice_mp3_path, format="mp3")
 
-        # transcribe
-        with open(voice_mp3_path, "rb") as f:
-            transcribed_text = await openai_utils.transcribe_audio(f)
+            # transcribe
+            with open(voice_mp3_path, "rb") as f:
+                transcribed_text = await openai_utils.transcribe_audio(f)
 
-    text = f"🎤: <i>{transcribed_text}</i>"
-    await update.message.reply_text(text, parse_mode=ParseMode.HTML)
+        text = f"🎤: <i>{transcribed_text}</i>"
+        await update.message.reply_text(text, parse_mode=ParseMode.HTML)
 
-    # update n_transcribed_seconds
-    db.set_user_attribute(user_id, "n_transcribed_seconds", voice.duration + db.get_user_attribute(user_id, "n_transcribed_seconds"))
+        # update n_transcribed_seconds
+        db.set_user_attribute(user_id, "n_transcribed_seconds", voice.duration + db.get_user_attribute(user_id, "n_transcribed_seconds"))
 
-    await message_handle(update, context, message=transcribed_text)
+        await message_handle(update, context, message=transcribed_text)
 
 
 async def new_dialog_handle(update: Update, context: CallbackContext):
+    global listening
+    listening = True
+
     await register_user_if_not_exists(update, context, update.message.from_user)
     if await is_previous_message_not_answered_yet(update, context): return
 
@@ -297,9 +305,17 @@ async def new_dialog_handle(update: Update, context: CallbackContext):
 
     db.start_new_dialog(user_id)
     await update.message.reply_text("Starting new dialog ✅")
-
+    
     chat_mode = db.get_user_attribute(user_id, "current_chat_mode")
     await update.message.reply_text(f"{openai_utils.CHAT_MODES[chat_mode]['welcome_message']}", parse_mode=ParseMode.HTML)
+
+async def stop_dialog_handle(update: Update, context: CallbackContext):
+    global listening
+    listening = False
+
+    await register_user_if_not_exists(update, context, update.message.from_user)
+    if await is_previous_message_not_answered_yet(update, context): return
+    await update.message.reply_text("Thank you, Have a nice day!")
 
 
 async def show_chat_modes_handle(update: Update, context: CallbackContext):
@@ -458,6 +474,7 @@ async def error_handle(update: Update, context: CallbackContext) -> None:
 async def post_init(application: Application):
     await application.bot.set_my_commands([
         BotCommand("/new", "Start new dialog"),
+        BotCommand("/stop", "Stop the dialog"),
         BotCommand("/mode", "Select chat mode"),
         BotCommand("/retry", "Re-generate response for previous query"),
         BotCommand("/balance", "Show balance"),
@@ -474,7 +491,6 @@ def run_bot() -> None:
         .post_init(post_init)
         .build()
     )
-
     # add handlers
     user_filter = filters.ALL
     if len(config.allowed_telegram_usernames) > 0:
@@ -482,23 +498,19 @@ def run_bot() -> None:
         user_ids = [x for x in config.allowed_telegram_usernames if isinstance(x, int)]
         user_filter = filters.User(username=usernames) | filters.User(user_id=user_ids)
 
-    application.add_handler(CommandHandler("start", start_handle, filters=user_filter))
     application.add_handler(CommandHandler("help", help_handle, filters=user_filter))
-
-    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND & user_filter, message_handle))
-    application.add_handler(CommandHandler("retry", retry_handle, filters=user_filter))
+    application.add_handler(CommandHandler("stop", stop_dialog_handle, filters=user_filter))
     application.add_handler(CommandHandler("new", new_dialog_handle, filters=user_filter))
 
+    application.add_handler(CommandHandler("start", start_handle, filters=user_filter))
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND & user_filter, message_handle))
+    application.add_handler(CommandHandler("retry", retry_handle, filters=user_filter))
     application.add_handler(MessageHandler(filters.VOICE & user_filter, voice_message_handle))
-    
     application.add_handler(CommandHandler("mode", show_chat_modes_handle, filters=user_filter))
     application.add_handler(CallbackQueryHandler(set_chat_mode_handle, pattern="^set_chat_mode"))
-
     application.add_handler(CommandHandler("settings", settings_handle, filters=user_filter))
     application.add_handler(CallbackQueryHandler(set_settings_handle, pattern="^set_settings"))
-
     application.add_handler(CommandHandler("balance", show_balance_handle, filters=user_filter))
-    
     application.add_error_handler(error_handle)
     
     # start the bot

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -115,22 +115,21 @@ async def help_handle(update: Update, context: CallbackContext):
 
 
 async def retry_handle(update: Update, context: CallbackContext):
-    if listening:
-        await register_user_if_not_exists(update, context, update.message.from_user)
-        if await is_previous_message_not_answered_yet(update, context): return
-        
-        user_id = update.message.from_user.id
-        db.set_user_attribute(user_id, "last_interaction", datetime.now())
+    await register_user_if_not_exists(update, context, update.message.from_user)
+    if await is_previous_message_not_answered_yet(update, context): return
+    
+    user_id = update.message.from_user.id
+    db.set_user_attribute(user_id, "last_interaction", datetime.now())
 
-        dialog_messages = db.get_dialog_messages(user_id, dialog_id=None)
-        if len(dialog_messages) == 0:
-            await update.message.reply_text("No message to retry 🤷‍♂️")
-            return
+    dialog_messages = db.get_dialog_messages(user_id, dialog_id=None)
+    if len(dialog_messages) == 0:
+        await update.message.reply_text("No message to retry 🤷‍♂️")
+        return
 
-        last_dialog_message = dialog_messages.pop()
-        db.set_dialog_messages(user_id, dialog_messages, dialog_id=None)  # last message was removed from the context
+    last_dialog_message = dialog_messages.pop()
+    db.set_dialog_messages(user_id, dialog_messages, dialog_id=None)  # last message was removed from the context
 
-        await message_handle(update, context, message=last_dialog_message["user"], use_new_dialog_timeout=False)
+    await message_handle(update, context, message=last_dialog_message["user"], use_new_dialog_timeout=False)
 
 
 async def message_handle(update: Update, context: CallbackContext, message=None, use_new_dialog_timeout=True):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -476,9 +476,9 @@ async def post_init(application: Application):
         BotCommand("/stop", "Stop the dialog"),
         BotCommand("/mode", "Select chat mode"),
         BotCommand("/retry", "Re-generate response for previous query"),
-        BotCommand("/balance", "Show balance"),
-        BotCommand("/settings", "Show settings"),
-        BotCommand("/help", "Show help message"),
+        # BotCommand("/balance", "Show balance"),
+        # BotCommand("/settings", "Show settings"),
+        # BotCommand("/help", "Show help message"),
     ])
 
 def run_bot() -> None:

--- a/config/chat_modes.yml
+++ b/config/chat_modes.yml
@@ -6,6 +6,12 @@ assistant:
     If user asks you about programming or asks to write code do not answer his question, but be sure to advise him to switch to a special mode \"👩🏼‍💻 Code Assistant\" by sending the command /mode to chat.
   parse_mode: html
 
+social_media_specialist:
+  name: 💎 Social Media Specialist
+  welcome_message: 💎 Hi, I'm <b>Social Media Specialist</b>. How can I help you?
+  prompt_start: |
+    As an advanced chatbot Social Media Specialist Assistant, your primary goal is to assist users to the best of your ability. You can answer questions about creating caption, campaign recommendation, social media planning, and more. You can recommend what the best solution to users based on their preferences. You can discuss about the question with users if the question doesn`t cleat, and provide helpful information about social media. In order to effectively assist users, it is important to be detailed and thorough in your responses. Use examples and evidence to support your points and justify your recommendations or solutions. Remember to always prioritize the needs and satisfaction of the user. Your ultimate goal is to provide a helpful and enjoyable experience for the user.
+  parse_mode: html
 
 code_assistant:
   name: 👩🏼‍💻 Code Assistant
@@ -27,11 +33,4 @@ text_improver:
 
     <b>Correction:</b>
     {NUMBERED LIST OF CORRECTIONS}
-  parse_mode: html
-
-movie_expert:
-  name: 🎬 Movie Expert
-  welcome_message: 🎬 Hi, I'm <b>Movie Expert</b>. How can I help you?
-  prompt_start: |
-    As an advanced chatbot Movie Expert Assistant, your primary goal is to assist users to the best of your ability. You can answer questions about movies, actors, directors, and more. You can recommend movies to users based on their preferences. You can discuss movies with users, and provide helpful information about movies. In order to effectively assist users, it is important to be detailed and thorough in your responses. Use examples and evidence to support your points and justify your recommendations or solutions. Remember to always prioritize the needs and satisfaction of the user. Your ultimate goal is to provide a helpful and enjoyable experience for the user.
   parse_mode: html


### PR DESCRIPTION
With the new "stop" command, group chat participants can quickly and easily pause the ChatGPT bot's responses, allowing for more focused conversations and less interruption.

To use the "stop" command, simply type "/stop" into the chat. To resume ChatGPT's responses, type "/new" or "/retry".