### PR TITLE
Automatically delete old dialogues from DB when initiating a new one

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -61,12 +61,15 @@ async def register_user_if_not_exists(update: Update, context: CallbackContext, 
             update.message.chat_id,
             username=user.username,
             first_name=user.first_name,
-            last_name= user.last_name
+            last_name=user.last_name
         )
-        db.start_new_dialog(user.id)
-
-    if db.get_user_attribute(user.id, "current_dialog_id") is None:
-        db.start_new_dialog(user.id)
+        current_dialog_id = db.start_new_dialog(user.id)
+    else:
+        current_dialog_id = db.get_user_attribute(user.id, "current_dialog_id")
+        if current_dialog_id is None:
+            current_dialog_id = db.start_new_dialog(user.id)
+        else:
+            db.delete_all_dialogs_except_current(user.id)
 
     if user.id not in user_semaphores:
         user_semaphores[user.id] = asyncio.Semaphore(1)
@@ -147,6 +150,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
         if use_new_dialog_timeout:
             if (datetime.now() - db.get_user_attribute(user_id, "last_interaction")).seconds > config.new_dialog_timeout and len(db.get_dialog_messages(user_id)) > 0:
                 db.start_new_dialog(user_id)
+                db.delete_all_dialogs_except_current(user_id)
                 await update.message.reply_text(f"Starting new dialog due to timeout (<b>{openai_utils.CHAT_MODES[chat_mode]['name']}</b> mode) ✅", parse_mode=ParseMode.HTML)
         db.set_user_attribute(user_id, "last_interaction", datetime.now())
 
@@ -296,6 +300,7 @@ async def new_dialog_handle(update: Update, context: CallbackContext):
     db.set_user_attribute(user_id, "last_interaction", datetime.now())
 
     db.start_new_dialog(user_id)
+    db.delete_all_dialogs_except_current(user_id)
     await update.message.reply_text("Starting new dialog ✅")
 
     chat_mode = db.get_user_attribute(user_id, "current_chat_mode")

--- a/bot/database.py
+++ b/bot/database.py
@@ -125,3 +125,11 @@ class Database:
             {"_id": dialog_id, "user_id": user_id},
             {"$set": {"messages": dialog_messages}}
         )
+
+    def delete_all_dialogs_except_current(self, user_id: int):
+        user = self.user_collection.find_one({"_id": user_id})
+        if not user:
+            raise ValueError(f"User with ID {user_id} does not exist")
+
+        current_dialog_id = user["current_dialog_id"]
+        self.dialog_collection.delete_many({"user_id": user_id, "_id": {"$ne": current_dialog_id}})


### PR DESCRIPTION
Currently, all user dialogues are kept and stored in MongoDB, even when a user begins a new dialogue or restarts the bot, which can become quite packed with useless data overtime as the user will not need these old dialogues at this stage of the project, especially if thousands of users use the bot. I also think it's much better from a user's privacy standpoint.

**With the changes below, old dialogues will be deleted from the database whether:**

1. User creates a new dialogue with /new
2. User stops and restarts the bot
3. Dialogue restarts due to timeout
4. User switches to another chat mode

I believe in the future we could look into keeping at least 5 dialogues and having a chat history option and possibility to switch to old contexts as on ChatGPT web.

Tried this on a test bot and it worked great. See if you find this useful not.