### PR TITLE
Housekeeping – add `.dockerignore`, add INFO level logging, slim dependencies in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/mongodb

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,13 @@ ENV PIP_NO_CACHE_DIR=off
 ENV PIP_DISABLE_PIP_VERSION_CHECK=on
 ENV PIP_DEFAULT_TIMEOUT=100
 
-RUN apt-get update
-RUN apt-get install -y python3 python3-pip python-dev build-essential python3-venv ffmpeg
+RUN apt-get update && \
+  apt-get install -y \
+    # required by the bot
+    python3-yaml python3-pymongo ffmpeg \
+    # debugging helpers
+    nano ripgrep && \
+  rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ ENV PIP_DEFAULT_TIMEOUT=100
 RUN apt-get update
 RUN apt-get install -y python3 python3-pip python-dev build-essential python3-venv ffmpeg
 
-RUN mkdir -p /code
-ADD . /code
 WORKDIR /code
 
+COPY requirements.txt /code/requirements.txt
 RUN pip3 install -r requirements.txt
+
+ADD . /code
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
 WORKDIR /code
 
 COPY requirements.txt /code/requirements.txt
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 ADD . /code
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -37,7 +37,7 @@ import openai_utils
 
 # setup
 db = database.Database()
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 user_semaphores = {}

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -37,6 +37,7 @@ import openai_utils
 
 # setup
 db = database.Database()
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 user_semaphores = {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   mongo:
     container_name: mongo
     image: mongo:latest
-    restart: always
+    restart: unless-stopped
     ports:
       - 127.0.0.1:${MONGODB_PORT:-27017}:${MONGODB_PORT:-27017}
     volumes:
@@ -14,17 +14,20 @@ services:
   chatgpt_telegram_bot:
     container_name: chatgpt_telegram_bot
     command: python3 bot/bot.py
-    restart: always
+    restart: unless-stopped
     build:
       context: "."
       dockerfile: Dockerfile
+    volumes:
+      - ./bot:/code/bot
+      - ./config:/code/config
     depends_on:
       - mongo
 
   mongo_express:
     container_name: mongo-express
     image: mongo-express:latest
-    restart: always
+    restart: unless-stopped
     ports:
       - 127.0.0.1:${MONGO_EXPRESS_PORT:-8081}:${MONGO_EXPRESS_PORT:-8081}
     environment:


### PR DESCRIPTION
1. Add `.dockerignore` with `/mongodb` as the only line, so one won't transfer entire MongoDB as context to bot Python container.
2. Add INFO level logging with `logging.basicConfig(level=logging.INFO)` so user won't question themselves if bot is running or not.
3. Slim dependencies in Dockerfile by installing only necessary Ubuntu packages and lower build time by rearranging Dockerfile instructions – now it caches pip packages install step properly.
4. Attach `bot` and `config` folders as volumes, so one can use `docker compose restart`.