### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=on
 ENV PIP_DEFAULT_TIMEOUT=100
 
 RUN apt-get update
-RUN apt-get install -y python3 python3-pip python-dev build-essential python3-venv ffmpeg
+RUN apt-get install -y python3 python3-pip python3-dev build-essential python3-venv ffmpeg
 
 RUN mkdir -p /code
 ADD . /code


### PR DESCRIPTION
Windows 10 bugfix

` => ERROR [chatgpt_telegram_bot 3/7] RUN apt-get install -y python3 python3-pip python-dev build-essential python  0.6s
------
 > [chatgpt_telegram_bot 3/7] RUN apt-get install -y python3 python3-pip python-dev build-essential python3-venv ffmpeg:#0 0.230 Reading package lists...
#0 0.470 Building dependency tree...
#0 0.540 Reading state information...
#0 0.543 Package python-dev is not available, but is referred to by another package.
#0 0.543 This may mean that the package is missing, has been obsoleted, or
#0 0.543 is only available from another source
#0 0.543 However the following packages replace it:
#0 0.543   python-dev-is-python3
#0 0.543
#0 0.544 E: Package 'python-dev' has no installation candidate
------
failed to solve: process "/bin/sh -c apt-get install -y python3 python3-pip python-dev build-essential python3-venv ffmpeg" did not complete successfully: exit code: 100`