### PR TITLE
create .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+mongodb
+  


### PR DESCRIPTION
allows for docker-compose build after the first initialisation