### PR TITLE
feat: update for the gpt-4-turbo-preview

### DIFF
--- a/bot/openai_utils.py
+++ b/bot/openai_utils.py
@@ -22,7 +22,7 @@ OPENAI_COMPLETION_OPTIONS = {
 
 class ChatGPT:
     def __init__(self, model="gpt-3.5-turbo"):
-        assert model in {"text-davinci-003", "gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4-1106-preview"}, f"Unknown model: {model}"
+        assert model in {"text-davinci-003", "gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4-turbo-preview"}, f"Unknown model: {model}"
         self.model = model
 
     async def send_message(self, message, dialog_messages=[], chat_mode="assistant"):
@@ -33,7 +33,7 @@ class ChatGPT:
         answer = None
         while answer is None:
             try:
-                if self.model in {"gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4-1106-preview"}:
+                if self.model in {"gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4-turbo-preview"}:
                     messages = self._generate_prompt_messages(message, dialog_messages, chat_mode)
                     r = await openai.ChatCompletion.acreate(
                         model=self.model,
@@ -73,7 +73,7 @@ class ChatGPT:
         answer = None
         while answer is None:
             try:
-                if self.model in {"gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4-1106-preview"}:
+                if self.model in {"gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4-turbo-preview"}:
                     messages = self._generate_prompt_messages(message, dialog_messages, chat_mode)
                     r_gen = await openai.ChatCompletion.acreate(
                         model=self.model,
@@ -161,7 +161,7 @@ class ChatGPT:
         elif model == "gpt-4":
             tokens_per_message = 3
             tokens_per_name = 1
-        elif model == "gpt-4-1106-preview":
+        elif model == "gpt-4-turbo-preview":
             tokens_per_message = 3
             tokens_per_name = 1
         else:

--- a/config/models.yml
+++ b/config/models.yml
@@ -1,9 +1,14 @@
-available_text_models: ["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4-1106-preview", "gpt-4", "text-davinci-003"]
+available_text_models: [
+  "gpt-3.5-turbo",
+  # "gpt-3.5-turbo-16k",
+  "gpt-4-turbo-preview",
+  # "gpt-4",
+]
 
 info:
   gpt-3.5-turbo:
     type: chat_completion
-    name: ChatGPT
+    name: ChatGPT 3.5 Turbo
     description: ChatGPT is that well-known model. It's <b>fast</b> and <b>cheap</b>. Ideal for everyday tasks. If there are some tasks it can't handle, try the <b>GPT-4</b>.
 
     price_per_1000_input_tokens: 0.0015
@@ -27,6 +32,7 @@ info:
       Fast: 5
       Cheap: 5
 
+# Info here https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
   gpt-4:
     type: chat_completion
     name: GPT-4
@@ -40,9 +46,9 @@ info:
       Fast: 2
       Cheap: 2
 
-  gpt-4-1106-preview:
+  gpt-4-turbo-preview:
     type: chat_completion
-    name: GPT-4 Turbo
+    name: GPT-4 Turbo Preview
     description: GPT-4 Turbo is a <b>faster</b> and <b>cheaper</b> version of GPT-4. It's as smart as GPT-4, so you should use it instead of GPT-4.
 
     price_per_1000_input_tokens: 0.01


### PR DESCRIPTION
Proposed to revise the model options. 

- added gpt4-turbo-preview tag, that automatically points to the latest gpt-4 "turbo-preview". 
- commented out the other legacy model, and gpt-4 , given it makes more sense to use the gpt-4-turbo-preview, more practical. 