### PR TITLE
Fix storing and passing previous messages to API

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -429,7 +429,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
                 prev_answer = answer
             
             # update user data
-            new_dialog_message = {"user": _message, "bot": answer, "date": datetime.now()}
+            new_dialog_message = {"user": [{"type": "text", "text": _message}], "bot": answer, "date": datetime.now()}
 
             db.set_dialog_messages(
                 user_id,

--- a/bot/openai_utils.py
+++ b/bot/openai_utils.py
@@ -254,25 +254,23 @@ class ChatGPT:
         prompt = config.chat_modes[chat_mode]["prompt_start"]
 
         messages = [{"role": "system", "content": prompt}]
-        user_messages = {"role": "user", "content": []}
         
         for dialog_message in dialog_messages:
-            user_messages["content"].extend(dialog_message["user"])
+            messages.append({"role": "user", "content": dialog_message["user"]})
             messages.append({"role": "assistant", "content": dialog_message["bot"]})
             
 
-        user_messages["content"].append({"type": "text", "text": message})
+        messages.append({"role": "user", "content": [{"type": "text", "text": message}]})
 
         if image_buffer is not None:
-            user_messages["content"].append(
+            messages[-1]["content"].append(
                 {
                     "type": "image",
                     "image": self._encode_image(image_buffer),
                 }
             )
 
-        response = messages + ([user_messages] if len(user_messages["content"]) > 0 else [])
-        return response
+        return messages
 
     def _postprocess_answer(self, answer):
         answer = answer.strip()


### PR DESCRIPTION
Critical bug: conversation history is lost, bot remembers only the current message

Current version does not pass chat history to the API correctly: `vision_message_handle_fn` introduced new format for saving user messages
```python
new_dialog_message = {"user": [{"type": "text", "text": message}], "bot": answer, "date": datetime.now()}
```
and `_generate_prompt_messages` has been changed accordingly.
But in `message_handle_fn` it is still
```python
new_dialog_message = {"user": _message, "bot": answer, "date": datetime.now()}
```
Call of `extend(dialog_message["user"])` for the dialog message saved in `message_handle_fn` results in splitting `dialog_message["user"]`= `_message` of type `str` into symbols, thus the structure in `response` is messed and API returns
something like ` error_code=None error_message="'$.messages[3].content' is invalid. Please check the API reference: https://platform.openai.com/docs/api-reference." error_param=None error_type=invalid_request_error message='OpenAI API error received' stream_error=False
chatgpt_telegram_bot  | 2024-04-09 18:47:58 DEBUG: message='Request to OpenAI API' method=post path=https://api.openai.com/v1/chat/completions
`
and finally ignores the conversation context.