### PR TITLE
Add option to enable Mongo host rename

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -21,7 +21,7 @@ enable_message_streaming = config_yaml.get("enable_message_streaming", True)
 return_n_generated_images = config_yaml.get("return_n_generated_images", 1)
 image_size = config_yaml.get("image_size", "512x512")
 n_chat_modes_per_page = config_yaml.get("n_chat_modes_per_page", 5)
-mongodb_uri = f"mongodb://mongo:{config_env['MONGODB_PORT']}"
+mongodb_uri = f"mongodb://{config_env['MONGODB_HOST']}:{config_env['MONGODB_PORT']}"
 
 # chat_modes
 with open(config_dir / "chat_modes.yml", 'r') as f:

--- a/config/config.example.env
+++ b/config/config.example.env
@@ -2,6 +2,8 @@
 MONGODB_PATH=./mongodb
 # MongoDB port
 MONGODB_PORT=27017
+# MongoDB host name
+MONGODB_HOST=mongo
 
 # Mongo Express port
 MONGO_EXPRESS_PORT=8081


### PR DESCRIPTION
It's a simple change, so that I can rename my container, as I already have another `mongo` and don't want to use the same instance.