### PR TITLE
Add support for GPT-4o

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -185,9 +185,9 @@ async def _vision_message_handle_fn(
     user_id = update.message.from_user.id
     current_model = db.get_user_attribute(user_id, "current_model")
 
-    if current_model != "gpt-4-vision-preview":
+    if current_model != "gpt-4-vision-preview" and current_model != "gpt-4o":
         await update.message.reply_text(
-            "🥲 Images processing is only available for <b>gpt-4-vision-preview</b> model. Please change your settings in /settings",
+            "🥲 Images processing is only available for <b>gpt-4-vision-preview</b> and <b>gpt-4o</b> model. Please change your settings in /settings",
             parse_mode=ParseMode.HTML,
         )
         return
@@ -459,11 +459,14 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
             await update.message.reply_text(text, parse_mode=ParseMode.HTML)
 
     async with user_semaphores[user_id]:
-        if current_model == "gpt-4-vision-preview" or update.message.photo is not None and len(update.message.photo) > 0:
-            logger.error('gpt-4-vision-preview')
-            if current_model != "gpt-4-vision-preview":
-                current_model = "gpt-4-vision-preview"
-                db.set_user_attribute(user_id, "current_model", "gpt-4-vision-preview")
+        if current_model == "gpt-4-vision-preview" or current_model == "gpt-4o" or update.message.photo is not None and len(update.message.photo) > 0:
+
+            logger.error(current_model)
+            # What is this? ^^^
+
+            if current_model != "gpt-4o":
+                current_model = "gpt-4o"
+                db.set_user_attribute(user_id, "current_model", "gpt-4o")
             task = asyncio.create_task(
                 _vision_message_handle_fn(update, context, use_new_dialog_timeout=use_new_dialog_timeout)
             )

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -464,7 +464,7 @@ async def message_handle(update: Update, context: CallbackContext, message=None,
             logger.error(current_model)
             # What is this? ^^^
 
-            if current_model != "gpt-4o":
+            if current_model != "gpt-4o" and current_model != "gpt-4-vision-preview":
                 current_model = "gpt-4o"
                 db.set_user_attribute(user_id, "current_model", "gpt-4o")
             task = asyncio.create_task(

--- a/bot/openai_utils.py
+++ b/bot/openai_utils.py
@@ -26,7 +26,7 @@ OPENAI_COMPLETION_OPTIONS = {
 
 class ChatGPT:
     def __init__(self, model="gpt-3.5-turbo"):
-        assert model in {"text-davinci-003", "gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4-1106-preview", "gpt-4-vision-preview"}, f"Unknown model: {model}"
+        assert model in {"text-davinci-003", "gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4o", "gpt-4-1106-preview", "gpt-4-vision-preview"}, f"Unknown model: {model}"
         self.model = model
 
     async def send_message(self, message, dialog_messages=[], chat_mode="assistant"):
@@ -37,7 +37,7 @@ class ChatGPT:
         answer = None
         while answer is None:
             try:
-                if self.model in {"gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4-1106-preview", "gpt-4-vision-preview"}:
+                if self.model in {"gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4o", "gpt-4-1106-preview", "gpt-4-vision-preview"}:
                     messages = self._generate_prompt_messages(message, dialog_messages, chat_mode)
 
                     r = await openai.ChatCompletion.acreate(
@@ -78,7 +78,7 @@ class ChatGPT:
         answer = None
         while answer is None:
             try:
-                if self.model in {"gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4", "gpt-4-1106-preview"}:
+                if self.model in {"gpt-3.5-turbo-16k", "gpt-3.5-turbo", "gpt-4","gpt-4o", "gpt-4-1106-preview"}:
                     messages = self._generate_prompt_messages(message, dialog_messages, chat_mode)
 
                     r_gen = await openai.ChatCompletion.acreate(
@@ -138,7 +138,7 @@ class ChatGPT:
         answer = None
         while answer is None:
             try:
-                if self.model == "gpt-4-vision-preview":
+                if self.model == "gpt-4-vision-preview" or self.model == "gpt-4o":
                     messages = self._generate_prompt_messages(
                         message, dialog_messages, chat_mode, image_buffer
                     )
@@ -186,7 +186,7 @@ class ChatGPT:
         answer = None
         while answer is None:
             try:
-                if self.model == "gpt-4-vision-preview":
+                if self.model == "gpt-4-vision-preview" or self.model == "gpt-4o":
                     messages = self._generate_prompt_messages(
                         message, dialog_messages, chat_mode, image_buffer
                     )
@@ -269,8 +269,12 @@ class ChatGPT:
                             "text": message,
                         },
                         {
-                            "type": "image",
-                            "image": self._encode_image(image_buffer),
+                            "type": "image_url",
+                            "image_url" : {
+                              
+                                "url": f"data:image/jpeg;base64,{self._encode_image(image_buffer)}",
+                                "detail":"high"
+                            }
                         }
                     ]
                 }
@@ -301,6 +305,9 @@ class ChatGPT:
             tokens_per_message = 3
             tokens_per_name = 1
         elif model == "gpt-4-vision-preview":
+            tokens_per_message = 3
+            tokens_per_name = 1
+        elif model == "gpt-4o":
             tokens_per_message = 3
             tokens_per_name = 1
         else:

--- a/config/models.yml
+++ b/config/models.yml
@@ -65,6 +65,18 @@ info:
       smart: 5
       fast: 4
       cheap: 3
+  gpt-4o:
+    type: chat_completion
+    name: GPT-4o
+    description: GPT-4o is a special variant of GPT-4 designed for optimal performance and accuracy. Suitable for complex and detailed tasks.
+
+    price_per_1000_input_tokens: 0.03
+    price_per_1000_output_tokens: 0.06
+
+    scores:
+      smart: 5
+      fast: 2
+      cheap: 2
 
   text-davinci-003:
     type: completion

--- a/config/models.yml
+++ b/config/models.yml
@@ -1,4 +1,4 @@
-available_text_models: ["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4-1106-preview", "gpt-4-vision-preview", "gpt-4", "text-davinci-003"]
+available_text_models: ["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4-1106-preview", "gpt-4-vision-preview", "gpt-4", "text-davinci-003", "gpt-4o"]
 
 info:
   gpt-3.5-turbo:


### PR DESCRIPTION
Hello! I added support for GPT-4o. It now defaults over GPT-4-vision-preview. But you can still use GPT-4-vision-preview if you explicitly select it in settings

Also looking forward to PR my update from openai 0.28.0 to 1.30.1